### PR TITLE
Remove dependency from mavros_controllers

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -3,9 +3,6 @@
     uri: https://github.com/mavlink/mavros.git
     version: c373472c75310d1b76f40d2e4ea8b0b72f894e36
 - git:
-    local-name: mavros_controllers
-    uri: https://github.com/Jaeyoung-Lim/mavros_controllers.git
-- git:
     local-name: catkin_simple
     uri : https://github.com/catkin/catkin_simple.git
 - git:

--- a/humantracking_controller/include/humantracking_controller/humantracking_controller.h
+++ b/humantracking_controller/include/humantracking_controller/humantracking_controller.h
@@ -9,8 +9,6 @@
 #include "mavros_msgs/ActuatorControl.h"
 #include "mavros_msgs/MountControl.h"
 
-#include "geometric_controller/geometric_controller.h"
-
 using namespace std;
 using namespace Eigen;
 class HumanTrackingCtrl
@@ -29,8 +27,6 @@ class HumanTrackingCtrl
     void PublishActuatorSetpoints();
     void PublishMountControl();
     void PointGimbalToPoint(Eigen::Vector3d roi_point);
-
-    geometricCtrl geometric_controller_;
 
     double gimbal_pitch_;
     double gimbal_yaw_;

--- a/humantracking_controller/package.xml
+++ b/humantracking_controller/package.xml
@@ -16,25 +16,20 @@
   <build_depend>catkin_simple</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>controller_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>mavros_msgs</build_depend>
   <build_depend>mavros_extras</build_depend>
   <build_depend> eigen_catkin</build_depend>
-  <build_depend>geometric_controller</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>catkin_simple</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <run_depend>controller_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>mavros</run_depend>
   <run_depend>mavros_extras</run_depend>
   <run_depend>mavros_msgs</run_depend>
-  <run_depend>geometric_controller</run_depend>
-  <run_depend>trajectory_publisher</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/humantracking_controller/src/humantracking_controller.cpp
+++ b/humantracking_controller/src/humantracking_controller.cpp
@@ -7,8 +7,7 @@ using namespace std;
 //Constructor
 HumanTrackingCtrl::HumanTrackingCtrl(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
   nh_(nh),
-  nh_private_(nh_private),
-  geometric_controller_(nh, nh_private) {
+  nh_private_(nh_private) {
 
   cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &HumanTrackingCtrl::CmdLoopCallback, this); // Define timer for constant loop rate
   statusloop_timer_ = nh_.createTimer(ros::Duration(1), &HumanTrackingCtrl::StatusLoopCallback, this); // Define timer for constant loop rate
@@ -24,8 +23,6 @@ HumanTrackingCtrl::~HumanTrackingCtrl() {
 }
 
 void HumanTrackingCtrl::CmdLoopCallback(const ros::TimerEvent& event){
-
-  geometric_controller_.getStates(mav_pos_, mav_att_, mav_vel_, mav_bodyrate_);
 
   PointGimbalToPoint(tracking_pos_);
   // PublishActuatorSetpoints();


### PR DESCRIPTION
This PR removes the dependency from mavros_controllers.

The initial intention was to use the geometric_controller controlling the drone for target tracking, but this needs to be separted out as it is not functionally dependent. 