### PR TITLE
Add Subscriber for point of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 `mavros_humantracking` is a package enabling image based object tracking with a gimbal attached to a drone. It uses the `MountControlPlugin` in [mavros](https://github.com/mavlink/mavros)
 
 ![multiuavsitl](mavros_humantracking/resource/humantracking.gif)
+
+# Nodes
+- humantracking_controller
+    - Subscribed Topics
+        - `~point_of_interest` ([geometry_msgs/PointStamped](http://docs.ros.org/api/geometry_msgs/html/msg/PointStamped.html))
+            Point where the gimbal should be pointed at

--- a/humantracking_controller/include/humantracking_controller/humantracking_controller.h
+++ b/humantracking_controller/include/humantracking_controller/humantracking_controller.h
@@ -8,6 +8,7 @@
 
 #include "mavros_msgs/ActuatorControl.h"
 #include "mavros_msgs/MountControl.h"
+#include "geometry_msgs/PointStamped.h"
 
 using namespace std;
 using namespace Eigen;
@@ -20,6 +21,8 @@ class HumanTrackingCtrl
     ros::Publisher actuator_setpoint_pub_;
     ros::Publisher mount_control_pub_;
 
+    ros::Subscriber point_of_interest_sub_;
+
     ros::Timer cmdloop_timer_, statusloop_timer_;
 
     void CmdLoopCallback(const ros::TimerEvent& event);
@@ -27,6 +30,7 @@ class HumanTrackingCtrl
     void PublishActuatorSetpoints();
     void PublishMountControl();
     void PointGimbalToPoint(Eigen::Vector3d roi_point);
+    void PointOfInterestCallback(const geometry_msgs::PointStamped &msg);
 
     double gimbal_pitch_;
     double gimbal_yaw_;

--- a/humantracking_controller/src/humantracking_controller.cpp
+++ b/humantracking_controller/src/humantracking_controller.cpp
@@ -15,6 +15,8 @@ HumanTrackingCtrl::HumanTrackingCtrl(const ros::NodeHandle& nh, const ros::NodeH
   actuator_setpoint_pub_ = nh_.advertise<mavros_msgs::ActuatorControl>("/mavros/actuator_control", 1);
   mount_control_pub_ = nh_.advertise<mavros_msgs::MountControl>("/mavros/mount_control/command", 1);
 
+  point_of_interest_sub_ = nh_private_.subscribe("point_of_interest", 1, &HumanTrackingCtrl::PointOfInterestCallback, this,ros::TransportHints().tcpNoDelay());
+
   gimbal_pitch_ = 0.0;
   tracking_pos_ << 0.0, 0.0, 0.0;
 }
@@ -32,6 +34,14 @@ void HumanTrackingCtrl::CmdLoopCallback(const ros::TimerEvent& event){
 void HumanTrackingCtrl::StatusLoopCallback(const ros::TimerEvent& event){
 
 
+}
+
+void HumanTrackingCtrl::PointOfInterestCallback(const geometry_msgs::PointStamped &msg){
+
+  tracking_pos_(0) = msg.point.x;
+  tracking_pos_(1) = msg.point.y;
+  tracking_pos_(2) = msg.point.z;
+  
 }
 
 void HumanTrackingCtrl::PublishActuatorSetpoints(){


### PR DESCRIPTION
Until now, the point of interest (POI) was a constant value. This adds a subscriber so that the point of interest can be changed continuously through a ROS topic