### PR TITLE
Add geometric_controller back to the launchfile

### DIFF
--- a/humantracking_controller/include/humantracking_controller/humantracking_controller.h
+++ b/humantracking_controller/include/humantracking_controller/humantracking_controller.h
@@ -6,9 +6,10 @@
 #include <ros/ros.h>
 #include <Eigen/Dense>
 
-#include "mavros_msgs/ActuatorControl.h"
-#include "mavros_msgs/MountControl.h"
-#include "geometry_msgs/PointStamped.h"
+#include <mavros_msgs/ActuatorControl.h>
+#include <mavros_msgs/MountControl.h>
+#include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/PoseStamped.h>
 
 using namespace std;
 using namespace Eigen;
@@ -22,11 +23,13 @@ class HumanTrackingCtrl
     ros::Publisher mount_control_pub_;
 
     ros::Subscriber point_of_interest_sub_;
+    ros::Subscriber mav_pose_sub_;
 
     ros::Timer cmdloop_timer_, statusloop_timer_;
 
     void CmdLoopCallback(const ros::TimerEvent& event);
     void StatusLoopCallback(const ros::TimerEvent& event);
+    void mavposeCallback(const geometry_msgs::PoseStamped &msg);
     void PublishActuatorSetpoints();
     void PublishMountControl();
     void PointGimbalToPoint(Eigen::Vector3d roi_point);

--- a/humantracking_controller/launch/sitl_humantrack_circle.launch
+++ b/humantracking_controller/launch/sitl_humantrack_circle.launch
@@ -24,16 +24,18 @@
           <param name="max_acc" value="10.0" />
           <param name="Kp_x" value="8.0" />
           <param name="Kp_y" value="8.0" />
-          <param name="Kp_z" value="10.0" />
+          <param name="Kp_z" value="8.0" />
   </node>
 
   <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">
         <param name="trajectory_type" value="1" />
         <param name="shape_omega" value="1.2" />
         <param name="initpos_z" value="2.0" />
-        <param name="max_acc" value="10.0" />
         <param name="reference_type" value="2" />
   </node>
+
+  <!-- Launch rqt_reconfigure -->
+  <node pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen" name="rqt_reconfigure" />
 
   <include file="$(find mavros)/launch/node.launch">
       <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
@@ -53,7 +55,7 @@
   </include>
 
   <group if="$(arg visualization)">
-      <node type="rviz" name="rviz" pkg="rviz" args="-d $(find humantracking_controller)/launch/config_file.rviz" />
+      <node type="rviz" name="rviz" pkg="rviz" args="-d $(find geometric_controller)/launch/config_file.rviz" />
   </group>
 
 </launch>

--- a/humantracking_controller/launch/sitl_humantrack_circle.launch
+++ b/humantracking_controller/launch/sitl_humantrack_circle.launch
@@ -13,17 +13,18 @@
   
   <node pkg="humantracking_controller" type="humantracking_controller_node" name="humantracking_controller" output="screen">
   		<param name="mav_name" type="string" value="$(arg mav_name)" />
-        <remap from="command/bodyrate_command" to="/mavros/setpoint_raw/attitude"/>
-        <param name="ctrl_mode" value="$(arg command_input)" />
-         <param name="enable_sim" value="$(arg gazebo_simulation)" />
-        <param name="enable_gazebo_state" value="true"/>
-        <param name="attctrl_constant" value="0.3"/>
-        <param name="Kp_x" value="8.0" />
-        <param name="Kp_y" value="8.0" />
-        <param name="Kp_z" value="8.0" />
-        <param name="Kv_x" value="3.5" />
-        <param name="Kv_y" value="3.5" />
-        <param name="Kv_z" value="3.3" />
+  </node>
+
+  <node pkg="geometric_controller" type="geometric_controller_node" name="geometric_controller" output="screen">
+  		<param name="mav_name" type="string" value="$(arg mav_name)" />
+          <remap from="command/bodyrate_command" to="/mavros/setpoint_raw/attitude"/>
+          <param name="ctrl_mode" value="$(arg command_input)" />
+          <param name="enable_sim" value="$(arg gazebo_simulation)" />
+          <param name="enable_gazebo_state" value="true"/>
+          <param name="max_acc" value="10.0" />
+          <param name="Kp_x" value="8.0" />
+          <param name="Kp_y" value="8.0" />
+          <param name="Kp_z" value="10.0" />
   </node>
 
   <node pkg="trajectory_publisher" type="trajectory_publisher" name="trajectory_publisher" output="screen">

--- a/humantracking_controller/src/humantracking_controller.cpp
+++ b/humantracking_controller/src/humantracking_controller.cpp
@@ -16,7 +16,7 @@ HumanTrackingCtrl::HumanTrackingCtrl(const ros::NodeHandle& nh, const ros::NodeH
   mount_control_pub_ = nh_.advertise<mavros_msgs::MountControl>("/mavros/mount_control/command", 1);
 
   point_of_interest_sub_ = nh_private_.subscribe("point_of_interest", 1, &HumanTrackingCtrl::PointOfInterestCallback, this,ros::TransportHints().tcpNoDelay());
-
+  mav_pose_sub_ = nh_.subscribe("/mavros/local_position/pose", 1, &HumanTrackingCtrl::mavposeCallback, this, ros::TransportHints().tcpNoDelay());
   gimbal_pitch_ = 0.0;
   tracking_pos_ << 0.0, 0.0, 0.0;
 }
@@ -81,5 +81,12 @@ void HumanTrackingCtrl::PointGimbalToPoint(Eigen::Vector3d roi_point){
 
   gimbal_pitch_ = std::atan2(error_vec(2), distance_2d);
   gimbal_yaw_ = -std::atan2(error_vec(1), error_vec(0));
+
+}
+
+void HumanTrackingCtrl::mavposeCallback(const geometry_msgs::PoseStamped &msg) {
+  mav_pos_(0) = msg.pose.position.x;
+  mav_pos_(1) = msg.pose.position.y;
+  mav_pos_(2) = msg.pose.position.z;
 
 }


### PR DESCRIPTION
This PR adds the geometric_controllre back to the launchfile to automate arming / flying

Fixes a regression where the mav position was not being read anymore from mavros