### PR TITLE
Build with cmake and not catkin simple

### DIFF
--- a/humantracking_controller/CMakeLists.txt
+++ b/humantracking_controller/CMakeLists.txt
@@ -1,30 +1,66 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(humantracking_controller)
 
-include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
-
-find_package(catkin_simple REQUIRED)
-catkin_simple(ALL_DEPS_REQUIRED)
-
 add_definitions(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  tf
+  mavros
+  mavros_extras
+  mavros_msgs
+  mavlink
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES geometric_controller
+  CATKIN_DEPENDS roscpp rospy std_msgs mavros_msgs geometry_msgs
+)
+
+include_directories(
+  include
+  ${Boost_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS}
+  ${Eigen_INCLUDE_DIRS}
+)
+
 
 #############
 # LIBRARIES #
 #############
-cs_add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME}
   src/humantracking_controller.cpp 
 )
+add_dependencies(humantracking_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ############
 # BINARIES #
 ############
-cs_add_executable(humantracking_controller_node
+add_executable(humantracking_controller_node
   src/humantracking_controller_node.cpp
 )
+add_dependencies(humantracking_controller_node humantracking_controller ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(humantracking_controller_node ${PROJECT_NAME} ${catkin_LIBRARIES})
 ##########
 # EXPORT #
 ##########
-cs_install()
-cs_export()
+
+##########
+# TESTING#
+##########
+
+if(CATKIN_ENABLE_TESTING)
+    # Add gtest based cpp test target and link libraries
+    catkin_add_gtest(${PROJECT_NAME}-test test/main.cpp
+                                          test/test_example.cpp
+    )
+    if(TARGET ${PROJECT_NAME}-test)
+        target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}
+                                                 ${catkin_LIBRARIES}
+        )
+    endif()
+
+endif()

--- a/humantracking_controller/package.xml
+++ b/humantracking_controller/package.xml
@@ -13,7 +13,6 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>catkin_simple</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf</build_depend>
@@ -22,7 +21,6 @@
   <build_depend> eigen_catkin</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>catkin_simple</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/humantracking_controller/test/main.cpp
+++ b/humantracking_controller/test/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/humantracking_controller/test/test_example.cpp
+++ b/humantracking_controller/test/test_example.cpp
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <string>
+using std::string;
+
+class StringTest : public ::testing::Test {
+ public:
+  string actualString;
+  string wrongString;
+  string expectString;
+
+  char *actualValTrue;
+  char *actualValFalse;
+  char *expectVal;
+
+  // Use this method to set up any state that you need for all of your tests
+  void SetUp() override {
+    actualString = "hello gtest";
+    wrongString = "hello world";
+    expectString = "hello gtest";
+
+    actualValTrue = new char[actualString.size() + 1];
+    strncpy(actualValTrue, actualString.c_str(), actualString.size() + 1);
+
+    actualValFalse = new char[wrongString.size() + 1];
+    strncpy(actualValFalse, wrongString.c_str(), wrongString.size() + 1);
+
+    expectVal = new char[expectString.size() + 1];
+    strncpy(expectVal, expectString.c_str(), expectString.size() + 1);
+  }
+
+  // Use this method to clean up any memory, network etc. after each test
+  void TearDown() override {
+    delete[] actualValTrue;
+    delete[] actualValFalse;
+    delete[] expectVal;
+  }
+};
+
+// Example code we are testing:
+namespace myNormalCode {
+
+void reverseInPlace(string &toReverse) {
+  // NB! this only works for ASCII
+  for (int i = 0, j = toReverse.size() - 1; i < j; i++, j--) {
+    char tmp = toReverse[i];
+    toReverse[i] = toReverse[j];
+    toReverse[j] = tmp;
+  }
+}
+}  // namespace myNormalCode
+
+TEST_F(StringTest, StrEqual) {
+  // GIVEN: two strings that are the same
+
+  // THEN: we expect them to be equal
+  EXPECT_STREQ(actualString.c_str(), expectString.c_str());
+}
+
+TEST_F(StringTest, CStrNotEqual) {
+  // GIVEN: two char* that are NOT the same
+
+  // THEN: we expect them to be not equal
+  EXPECT_STRNE(expectVal, actualValFalse);
+}
+
+TEST_F(StringTest, testReverse) {
+  // GIVEN: a string, and a manually reversed string as well
+  string toReverse = actualString;
+  const string expectedReversed = "tsetg olleh";
+
+  // WHEN: we reverse the string
+  myNormalCode::reverseInPlace(toReverse);
+
+  // THEN: they should be the same
+  EXPECT_STREQ(expectedReversed.c_str(), toReverse.c_str());
+}


### PR DESCRIPTION
**Problem Description**
This removes the dependency to `catkin_simple` and uses regular cmake. This enables the package to run tests more simply